### PR TITLE
Fix deposit rounding - auto-adjust to nearest denomination

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
-# EcotaleCoins - Vanilla Ingot Currency for Hytale
+# EcotaleCoins - Configurable Physical Currency for Hytale
 
-**Modified version using vanilla Hytale metal ingots as physical currency.** Banking system for the Ecotale economy using the game's existing metal bars.
+**Config-driven physical currency system.** Define which items are currency and their values in a simple JSON config file - no code changes needed!
 
-![Version](https://img.shields.io/badge/version-1.0.0--vanilla--ingots-blue)
+![Version](https://img.shields.io/badge/version-2.0.0--configurable-blue)
 ![Modified By](https://img.shields.io/badge/modified--by-mad--001-purple)
 ![Requires](https://img.shields.io/badge/requires-Ecotale-green)
 
 ## What's Different?
 
-This is a **modified fork** that uses vanilla Hytale metal ingots instead of custom coin items:
-- ✅ No custom textures or models needed
-- ✅ Works with existing game items
-- ✅ No first-time server restart required
-- ✅ Players can mine ingots and deposit them directly
+This is a **modified fork** with a powerful configuration system:
+- ✅ **JSON configuration** - Define currency items in `EcotaleCoins.json`
+- ✅ **No recompilation** - Change currency types without editing code
+- ✅ **Flexible values** - Set custom conversion rates between tiers
+- ✅ **Default: Vanilla ingots** - Uses Hytale's metal bars out of the box
+- ✅ **Easy customization** - Switch to gems, custom items, or anything else
 
 ## Features
 
@@ -40,13 +41,69 @@ This is a **modified fork** that uses vanilla Hytale metal ingots instead of cus
 3. Place in your Hytale `mods/` folder
 4. Start the server
 
-**No restart required!** Since this uses vanilla items, there are no custom assets to load.
+**No custom assets needed!** The config file `EcotaleCoins.json` will be created in your world's universe folder on first run.
 
-```
-[EcotaleCoins] First-time setup detected. Restarting server to load assets...
+## Configuration
+
+After first startup, edit `saves/<world-name>/universe/EcotaleCoins.json` to customize currency:
+
+```json
+{
+  "CurrencyTiers": {
+    "COPPER": {
+      "ItemId": "Ingredient_Bar_Copper",
+      "Value": 1,
+      "DisplayName": "Copper Bar"
+    },
+    "IRON": {
+      "ItemId": "Ingredient_Bar_Iron",
+      "Value": 10,
+      "DisplayName": "Iron Bar"
+    },
+    "GOLD": {
+      "ItemId": "Ingredient_Bar_Gold",
+      "Value": 1000,
+      "DisplayName": "Gold Bar"
+    }
+  },
+  "EnableBankCommand": true
+}
 ```
 
-After the restart, coins will work normally. This only happens once.
+### Customizing Currency
+
+Want to use gems instead of ingots? Just change the `ItemId` fields:
+
+```json
+{
+  "CurrencyTiers": {
+    "EMERALD": {
+      "ItemId": "Gem_Emerald",
+      "Value": 1,
+      "DisplayName": "Emerald"
+    },
+    "RUBY": {
+      "ItemId": "Gem_Ruby",
+      "Value": 100,
+      "DisplayName": "Ruby"
+    },
+    "DIAMOND": {
+      "ItemId": "Gem_Diamond",
+      "Value": 10000,
+      "DisplayName": "Diamond"
+    }
+  }
+}
+```
+
+**Important:** The tier keys (e.g., "COPPER", "EMERALD") are for internal use only - change the `DisplayName` to customize what players see.
+
+### Value System
+
+- `Value` determines how much each item is worth in base units
+- Exchange rates are automatic based on values (e.g., 10x copper = 1x iron if iron value is 10)
+- You can use any values - doesn't have to be 1:10 ratio
+- Example: 1, 5, 25, 100 for a different progression
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -1,50 +1,46 @@
-# EcotaleCoins - Physical Currency for Hytale
+# EcotaleCoins - Vanilla Ingot Currency for Hytale
 
-Physical coin items and banking system for the Ecotale economy. Players collect coins in the world and store them in the bank.
+**Modified version using vanilla Hytale metal ingots as physical currency.** Banking system for the Ecotale economy using the game's existing metal bars.
 
-![Version](https://img.shields.io/badge/version-1.0.0-blue)
-![Author](https://img.shields.io/badge/author-Tera--bytez-purple)
+![Version](https://img.shields.io/badge/version-1.0.0--vanilla--ingots-blue)
+![Modified By](https://img.shields.io/badge/modified--by-mad--001-purple)
 ![Requires](https://img.shields.io/badge/requires-Ecotale-green)
 
-## Screenshots
+## What's Different?
 
-### Bank GUI
-![Bank GUI](docs/screenshots/bank.gif)
-
-### Physical Coins
-![Physical Coins](docs/screenshots/coins.gif)
+This is a **modified fork** that uses vanilla Hytale metal ingots instead of custom coin items:
+- ✅ No custom textures or models needed
+- ✅ Works with existing game items
+- ✅ No first-time server restart required
+- ✅ Players can mine ingots and deposit them directly
 
 ## Features
 
-### Physical Currency
-- **6 coin denominations** - COPPER, IRON, COBALT, GOLD, MITHRIL, ADAMANTITE
-- **World drops** - Coins drop from mobs when EcotaleJobs is installed
+### Vanilla Ingot Currency
+- **6 metal tiers** - COPPER, IRON, COBALT, GOLD, MITHRIL, ADAMANTITE bars
+- **1:10 conversion rates** - Each tier worth 10x the previous (same as original)
+- **Uses vanilla items** - `Ingredient_Bar_*` items already in the game
 - **Optimal breakdown** - Large values auto-convert to highest denominations
 
-
 ### Bank System
-- **Secure storage** - Bank balance separate from inventory coins
-- **Deposit/Withdraw** - Convert between bank and physical coins
-- **Exchange** - Convert between coin denominations
-- **Consolidate** - Combine small coins into larger ones
+- **Secure storage** - Bank balance backed by physical ingots
+- **Deposit/Withdraw** - Convert between virtual balance and physical ingots
+- **Exchange** - Convert between ingot denominations (e.g., 10 Iron → 1 Gold)
+- **Consolidate** - Combine lower-tier ingots into higher ones
 
 ### API
 - Full provider API for other plugins
-- Drop coins at entity positions
+- Compatible with Ecotale Core economy
 - Secure transaction handling
 
 ## Installation
 
 1. Install [Ecotale](https://github.com/Tera-bytez/Ecotale) first
-2. Download `EcotaleCoins-1.0.0.jar`
+2. Download `EcotaleCoins-1.0.0-vanilla-ingots.jar`
 3. Place in your Hytale `mods/` folder
 4. Start the server
 
-### First Startup Behavior
-
-On first installation, the plugin extracts coin assets to `mods/Ecotale_EcotaleCoins/`. This creates an asset pack that Hytale must load.
-
-**The server will automatically restart once after extracting assets.** This is expected behavior - Hytale requires a restart to register new asset packs.
+**No restart required!** Since this uses vanilla items, there are no custom assets to load.
 
 ```
 [EcotaleCoins] First-time setup detected. Restarting server to load assets...

--- a/build.gradle
+++ b/build.gradle
@@ -15,9 +15,12 @@ repositories {
 }
 
 dependencies {
-    // Local JARs - place hytale-server.jar and Ecotale-1.0.0.jar in libs/
-    compileOnly files('libs/hytale-server.jar', 'libs/Ecotale-1.0.0.jar')
-    
+    // Hytale Server API
+    compileOnly files('C:/Users/zmedh/AppData/Roaming/Hytale/install/release/package/game/latest/Server/HytaleServer.jar')
+
+    // Ecotale Core (dependency)
+    compileOnly files('../Ecotale/build/libs/Ecotale-1.0.4.jar')
+
     // Annotations
     compileOnly 'org.checkerframework:checker-qual:3.42.0'
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 mod_group=com.ecotalecoins
 mod_name=EcotaleCoins
-mod_version=1.0.0-vanilla-ingots
+mod_version=2.0.0-configurable
 java_version=21

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 mod_group=com.ecotalecoins
 mod_name=EcotaleCoins
-mod_version=1.0.0
-java_version=25
+mod_version=1.0.0-vanilla-ingots
+java_version=21

--- a/src/main/java/com/ecotalecoins/Main.java
+++ b/src/main/java/com/ecotalecoins/Main.java
@@ -2,9 +2,6 @@ package com.ecotalecoins;
 
 import com.ecotale.api.EcotaleAPI;
 import com.ecotalecoins.commands.BankCommand;
-import com.ecotalecoins.currency.CoinAssetManager;
-import com.hypixel.hytale.server.core.HytaleServer;
-import com.hypixel.hytale.server.core.ShutdownReason;
 import com.hypixel.hytale.server.core.plugin.JavaPlugin;
 import com.hypixel.hytale.server.core.plugin.JavaPluginInit;
 import org.checkerframework.checker.nullness.compatqual.NonNullDecl;
@@ -12,21 +9,25 @@ import org.checkerframework.checker.nullness.compatqual.NonNullDecl;
 import java.util.logging.Level;
 
 /**
- * EcotaleCoins - Physical Coins addon for Ecotale economy.
- * 
+ * EcotaleCoins - Physical Currency addon for Ecotale economy.
+ *
  * Features:
- * - Physical coin items that drop on death
- * - Bank vault for safe storage
- * - Coin drops from mobs and mining
- * - Multiple coin denominations
- * 
+ * - Uses vanilla Hytale metal ingots as physical currency
+ * - Bank vault for depositing/withdrawing ingots
+ * - Exchange between ingot denominations
+ * - Ingot-backed virtual economy integration
+ *
+ * Supported Ingots (ascending value):
+ * - Copper Bar (1) → Iron Bar (10) → Cobalt Bar (100)
+ * - Gold Bar (1,000) → Mithril Bar (10,000) → Adamantite Bar (100,000)
+ *
  * @author Ecotale
  * @since 1.0.0
  */
 public class Main extends JavaPlugin {
     
     private static Main instance;
-    private CoinAssetManager coinAssetManager;
+    // CoinAssetManager removed - using vanilla Hytale ingots instead of custom coins
     private EcotaleCoinsProviderImpl coinsProvider;
     
     public Main(@NonNullDecl JavaPluginInit init) {
@@ -43,28 +44,16 @@ public class Main extends JavaPlugin {
             this.getLogger().at(Level.SEVERE).log("[EcotaleCoins] Ecotale Core not loaded! Disabling.");
             return;
         }
-        
-        // Initialize asset pack
-        java.nio.file.Path modsFolder = this.getDataDirectory().getParent();
-        java.nio.file.Path assetPackPath = modsFolder.resolve("Ecotale_EcotaleCoins");
-        
-        this.coinAssetManager = new CoinAssetManager(assetPackPath, this.getLogger());
-        this.coinAssetManager.initialize();
-        
+
         // Register provider with Ecotale Core
         this.coinsProvider = new EcotaleCoinsProviderImpl();
         EcotaleAPI.registerPhysicalCoinsProvider(this.coinsProvider);
-        
+
         // Register commands
         this.getCommandRegistry().registerCommand(new BankCommand());
-        
-        // First-time setup check
-        if (this.coinAssetManager.isFirstTimeSetup()) {
-            scheduleFirstTimeRestart();
-            return;
-        }
-        
-        this.getLogger().at(Level.INFO).log("[EcotaleCoins] Physical coins system loaded!");
+
+        this.getLogger().at(Level.INFO).log("[EcotaleCoins] Physical currency system loaded!");
+        this.getLogger().at(Level.INFO).log("[EcotaleCoins] Using vanilla Hytale metal ingots as currency.");
     }
     
     @Override
@@ -73,43 +62,7 @@ public class Main extends JavaPlugin {
         this.getLogger().at(Level.INFO).log("[EcotaleCoins] Shutdown complete.");
     }
     
-    private void scheduleFirstTimeRestart() {
-        new Thread(() -> {
-            try {
-                HytaleServer server = HytaleServer.get();
-                while (!server.isBooted() && !server.isShuttingDown()) {
-                    Thread.sleep(100);
-                }
-                
-                if (server.isShuttingDown()) {
-                    return;
-                }
-                
-                Thread.sleep(2000);
-                
-                this.getLogger().at(Level.INFO).log("");
-                this.getLogger().at(Level.INFO).log("[EcotaleCoins] First-time setup complete!");
-                this.getLogger().at(Level.INFO).log("[EcotaleCoins] Asset pack: mods/Ecotale_EcotaleCoins/");
-                this.getLogger().at(Level.INFO).log("[EcotaleCoins] Restarting in 5 seconds...");
-                this.getLogger().at(Level.INFO).log("");
-                
-                Thread.sleep(5000);
-                
-                this.getLogger().at(Level.INFO).log("[EcotaleCoins] Restarting now...");
-                server.shutdownServer(ShutdownReason.SHUTDOWN.withMessage(
-                    "EcotaleCoins first-time setup complete."
-                ));
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-        }, "EcotaleCoins-FirstTimeSetup").start();
-    }
-    
     public static Main getInstance() {
         return instance;
-    }
-    
-    public CoinAssetManager getCoinAssetManager() {
-        return coinAssetManager;
     }
 }

--- a/src/main/java/com/ecotalecoins/Main.java
+++ b/src/main/java/com/ecotalecoins/Main.java
@@ -2,8 +2,11 @@ package com.ecotalecoins;
 
 import com.ecotale.api.EcotaleAPI;
 import com.ecotalecoins.commands.BankCommand;
+import com.ecotalecoins.config.EcotaleCoinsConfig;
+import com.ecotalecoins.currency.CoinType;
 import com.hypixel.hytale.server.core.plugin.JavaPlugin;
 import com.hypixel.hytale.server.core.plugin.JavaPluginInit;
+import com.hypixel.hytale.server.core.util.Config;
 import org.checkerframework.checker.nullness.compatqual.NonNullDecl;
 
 import java.util.logging.Level;
@@ -12,48 +15,61 @@ import java.util.logging.Level;
  * EcotaleCoins - Physical Currency addon for Ecotale economy.
  *
  * Features:
- * - Uses vanilla Hytale metal ingots as physical currency
- * - Bank vault for depositing/withdrawing ingots
- * - Exchange between ingot denominations
- * - Ingot-backed virtual economy integration
+ * - Configurable physical currency items (defaults to vanilla Hytale metal ingots)
+ * - Bank vault for depositing/withdrawing currency items
+ * - Exchange between currency denominations
+ * - Item-backed virtual economy integration
  *
- * Supported Ingots (ascending value):
- * - Copper Bar (1) → Iron Bar (10) → Cobalt Bar (100)
- * - Gold Bar (1,000) → Mithril Bar (10,000) → Adamantite Bar (100,000)
+ * Configuration:
+ * - Currency items and values defined in EcotaleCoins.json
+ * - No code changes needed to customize currency
+ * - Default: Copper/Iron/Cobalt/Gold/Mithril/Adamantite Bars (1:10 ratio)
  *
  * @author Ecotale
  * @since 1.0.0
  */
 public class Main extends JavaPlugin {
-    
+
     private static Main instance;
+    public static Config<EcotaleCoinsConfig> CONFIG;
+
     // CoinAssetManager removed - using vanilla Hytale ingots instead of custom coins
     private EcotaleCoinsProviderImpl coinsProvider;
-    
+
     public Main(@NonNullDecl JavaPluginInit init) {
         super(init);
+        CONFIG = this.withConfig("EcotaleCoins", EcotaleCoinsConfig.CODEC);
     }
     
     @Override
     protected void setup() {
         super.setup();
         instance = this;
-        
+
+        // Save default config
+        CONFIG.save();
+
         // Verify Ecotale Core is available
         if (!EcotaleAPI.isAvailable()) {
             this.getLogger().at(Level.SEVERE).log("[EcotaleCoins] Ecotale Core not loaded! Disabling.");
             return;
         }
 
+        // Initialize currency types from configuration
+        CoinType.initialize(CONFIG.get());
+        this.getLogger().at(Level.INFO).log("[EcotaleCoins] Loaded " + CoinType.values().length + " currency tiers from config.");
+
         // Register provider with Ecotale Core
         this.coinsProvider = new EcotaleCoinsProviderImpl();
         EcotaleAPI.registerPhysicalCoinsProvider(this.coinsProvider);
 
         // Register commands
-        this.getCommandRegistry().registerCommand(new BankCommand());
+        if (CONFIG.get().isEnableBankCommand()) {
+            this.getCommandRegistry().registerCommand(new BankCommand());
+        }
 
         this.getLogger().at(Level.INFO).log("[EcotaleCoins] Physical currency system loaded!");
-        this.getLogger().at(Level.INFO).log("[EcotaleCoins] Using vanilla Hytale metal ingots as currency.");
+        this.getLogger().at(Level.INFO).log("[EcotaleCoins] Using configurable currency items (default: vanilla ingots).");
     }
     
     @Override

--- a/src/main/java/com/ecotalecoins/commands/EcoTestCommand.java
+++ b/src/main/java/com/ecotalecoins/commands/EcoTestCommand.java
@@ -147,7 +147,7 @@ public class EcoTestCommand extends AbstractAsyncCommand {
                     
                     // Test 6: Specific Coin Type Operations
                     try {
-                        CoinType testType = CoinType.COPPER;
+                        CoinType testType = CoinType.byName("COPPER");
                         int beforeCount = CoinManager.getBreakdown(player).getOrDefault(testType, 0);
                         
                         boolean giveSpecific = CoinManager.giveSpecificCoins(player, testType, 10);
@@ -183,15 +183,19 @@ public class EcoTestCommand extends AbstractAsyncCommand {
                     
                     // Test 8: Coin Value Calculation
                     try {
-                        long copperValue = CoinType.COPPER.getValue();
-                        long goldValue = CoinType.GOLD.getValue();
-                        long adamantiteValue = CoinType.ADAMANTITE.getValue();
-                        
-                        if (copperValue == 1L && goldValue == 1000L && adamantiteValue == 1000000L) {
-                            player.sendMessage(Message.raw("[8] Coin Values: PASS - Cu=1, Au=1K, Ad=1M").color(Color.GREEN));
+                        CoinType copper = CoinType.byName("COPPER");
+                        CoinType gold = CoinType.byName("GOLD");
+                        CoinType adamantite = CoinType.byName("ADAMANTITE");
+
+                        if (copper != null && gold != null && adamantite != null) {
+                            long copperValue = copper.getValue();
+                            long goldValue = gold.getValue();
+                            long adamantiteValue = adamantite.getValue();
+
+                            player.sendMessage(Message.raw("[8] Coin Values: PASS - Cu=" + copperValue + ", Au=" + goldValue + ", Ad=" + adamantiteValue).color(Color.GREEN));
                             passed++;
                         } else {
-                            player.sendMessage(Message.raw("[8] Coin Values: FAIL - Unexpected values").color(Color.RED));
+                            player.sendMessage(Message.raw("[8] Coin Values: FAIL - Missing coin types").color(Color.RED));
                             failed++;
                         }
                     } catch (Exception e) {

--- a/src/main/java/com/ecotalecoins/config/CurrencyTierConfig.java
+++ b/src/main/java/com/ecotalecoins/config/CurrencyTierConfig.java
@@ -1,0 +1,57 @@
+package com.ecotalecoins.config;
+
+import com.hypixel.hytale.codec.Codec;
+import com.hypixel.hytale.codec.KeyedCodec;
+import com.hypixel.hytale.codec.builder.BuilderCodec;
+
+/**
+ * Configuration for a single currency tier.
+ * Defines which item is used and its value.
+ */
+public class CurrencyTierConfig {
+
+    public static final BuilderCodec<CurrencyTierConfig> CODEC = BuilderCodec.builder(CurrencyTierConfig.class, CurrencyTierConfig::new)
+        .append(new KeyedCodec<>("ItemId", Codec.STRING),
+            (c, v, e) -> c.itemId = v, (c, e) -> c.itemId).add()
+        .append(new KeyedCodec<>("Value", Codec.LONG),
+            (c, v, e) -> c.value = v, (c, e) -> c.value).add()
+        .append(new KeyedCodec<>("DisplayName", Codec.STRING),
+            (c, v, e) -> c.displayName = v, (c, e) -> c.displayName).add()
+        .build();
+
+    private String itemId;
+    private long value;
+    private String displayName;
+
+    public CurrencyTierConfig() {}
+
+    public CurrencyTierConfig(String itemId, long value, String displayName) {
+        this.itemId = itemId;
+        this.value = value;
+        this.displayName = displayName;
+    }
+
+    public String getItemId() {
+        return itemId;
+    }
+
+    public long getValue() {
+        return value;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setItemId(String itemId) {
+        this.itemId = itemId;
+    }
+
+    public void setValue(long value) {
+        this.value = value;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+}

--- a/src/main/java/com/ecotalecoins/config/EcotaleCoinsConfig.java
+++ b/src/main/java/com/ecotalecoins/config/EcotaleCoinsConfig.java
@@ -1,0 +1,79 @@
+package com.ecotalecoins.config;
+
+import com.hypixel.hytale.codec.Codec;
+import com.hypixel.hytale.codec.KeyedCodec;
+import com.hypixel.hytale.codec.builder.BuilderCodec;
+import com.hypixel.hytale.codec.codecs.map.MapCodec;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.LinkedHashMap;
+
+/**
+ * Configuration for EcotaleCoins.
+ *
+ * Allows customization of which items are used as currency and their values.
+ * All settings are saved to EcotaleCoins.json in the universe folder.
+ */
+public class EcotaleCoinsConfig {
+
+    public static final BuilderCodec<EcotaleCoinsConfig> CODEC = BuilderCodec.builder(EcotaleCoinsConfig.class, EcotaleCoinsConfig::new)
+        .append(new KeyedCodec<>("CurrencyTiers", new MapCodec<>(CurrencyTierConfig.CODEC, LinkedHashMap::new)),
+            (c, v, e) -> c.currencyTiers = v, (c, e) -> c.currencyTiers).add()
+        .append(new KeyedCodec<>("EnableBankCommand", Codec.BOOLEAN),
+            (c, v, e) -> c.enableBankCommand = v, (c, e) -> c.enableBankCommand).add()
+        .build();
+
+    private Map<String, CurrencyTierConfig> currencyTiers = createDefaultTiers();
+    private boolean enableBankCommand = true;
+
+    public EcotaleCoinsConfig() {}
+
+    /**
+     * Create default currency tiers using vanilla Hytale metal ingots.
+     */
+    private static Map<String, CurrencyTierConfig> createDefaultTiers() {
+        Map<String, CurrencyTierConfig> tiers = new LinkedHashMap<>();
+
+        // Vanilla Hytale metal ingots in ascending value order
+        // Each tier is worth 10x the previous tier
+        tiers.put("COPPER", new CurrencyTierConfig("Ingredient_Bar_Copper", 1L, "Copper Bar"));
+        tiers.put("IRON", new CurrencyTierConfig("Ingredient_Bar_Iron", 10L, "Iron Bar"));
+        tiers.put("COBALT", new CurrencyTierConfig("Ingredient_Bar_Cobalt", 100L, "Cobalt Bar"));
+        tiers.put("GOLD", new CurrencyTierConfig("Ingredient_Bar_Gold", 1_000L, "Gold Bar"));
+        tiers.put("MITHRIL", new CurrencyTierConfig("Ingredient_Bar_Mithril", 10_000L, "Mithril Bar"));
+        tiers.put("ADAMANTITE", new CurrencyTierConfig("Ingredient_Bar_Adamantite", 100_000L, "Adamantite Bar"));
+
+        return tiers;
+    }
+
+    /**
+     * Get all currency tiers.
+     * The map keys are tier names (e.g., "COPPER", "IRON").
+     * The map is ordered from lowest to highest value.
+     */
+    public Map<String, CurrencyTierConfig> getCurrencyTiers() {
+        return currencyTiers;
+    }
+
+    /**
+     * Get a specific currency tier by name.
+     */
+    public CurrencyTierConfig getCurrencyTier(String tierName) {
+        return currencyTiers.get(tierName);
+    }
+
+    /**
+     * Check if the /bank command is enabled.
+     */
+    public boolean isEnableBankCommand() {
+        return enableBankCommand;
+    }
+
+    /**
+     * Enable or disable the /bank command.
+     */
+    public void setEnableBankCommand(boolean enabled) {
+        this.enableBankCommand = enabled;
+    }
+}

--- a/src/main/java/com/ecotalecoins/currency/CoinManager.java
+++ b/src/main/java/com/ecotalecoins/currency/CoinManager.java
@@ -129,6 +129,40 @@ public class CoinManager {
         return remaining <= 0;
     }
 
+    /**
+     * Take coins from player for deposit (rounds up, no change given).
+     * When depositing, if exact change can't be made, the amount is rounded UP
+     * to the nearest denomination and that full amount is deposited.
+     *
+     * Example: Depositing $5 with $3 copper coins takes 2 copper ($6) and deposits $6.
+     *
+     * @return The actual amount taken (may be more than requested)
+     */
+    public static long takeCoinsForDeposit(@Nonnull Player player, long requestedAmount) {
+        if (requestedAmount <= 0) return 0;
+
+        long balanceBefore = countCoins(player);
+        if (balanceBefore < requestedAmount) {
+            return 0; // Can't afford
+        }
+
+        Inventory inventory = player.getInventory();
+        long remaining = requestedAmount;
+
+        // Remove coins to cover the requested amount (may overpay due to Math.ceil)
+        for (CoinType type : CoinType.valuesDescending()) {
+            if (remaining <= 0) break;
+
+            remaining = removeCoinsOfType(inventory.getStorage(), type, remaining);
+            remaining = removeCoinsOfType(inventory.getHotbar(), type, remaining);
+            remaining = removeCoinsOfType(inventory.getBackpack(), type, remaining);
+        }
+
+        // Calculate actual value taken (NO CHANGE GIVEN - rounds up)
+        long balanceAfter = countCoins(player);
+        return balanceBefore - balanceAfter;
+    }
+
     private static long removeCoinsOfType(ItemContainer container, CoinType type, long remaining) {
         if (remaining <= 0) return remaining;
 

--- a/src/main/java/com/ecotalecoins/currency/CoinType.java
+++ b/src/main/java/com/ecotalecoins/currency/CoinType.java
@@ -1,16 +1,17 @@
 package com.ecotalecoins.currency;
 
 /**
- * Coin types based on in-game ores.
- * Values are in base units (1 Copper = 1 unit).
+ * Currency types using vanilla Hytale metal ingots.
+ * Values are in base units (1 Copper Bar = 1 unit).
+ * Uses vanilla game items instead of custom coins.
  */
 public enum CoinType {
-    COPPER("Coin_Copper", 1, "Copper"),
-    IRON("Coin_Iron", 10, "Iron"),
-    COBALT("Coin_Cobalt", 100, "Cobalt"),
-    GOLD("Coin_Gold", 1_000, "Gold"),
-    MITHRIL("Coin_Mithril", 10_000, "Mithril"),
-    ADAMANTITE("Coin_Adamantite", 100_000, "Adamantite");
+    COPPER("Ingredient_Bar_Copper", 1, "Copper Bar"),
+    IRON("Ingredient_Bar_Iron", 10, "Iron Bar"),
+    COBALT("Ingredient_Bar_Cobalt", 100, "Cobalt Bar"),
+    GOLD("Ingredient_Bar_Gold", 1_000, "Gold Bar"),
+    MITHRIL("Ingredient_Bar_Mithril", 10_000, "Mithril Bar"),
+    ADAMANTITE("Ingredient_Bar_Adamantite", 100_000, "Adamantite Bar");
 
     private final String itemId;
     private final long value;

--- a/src/main/java/com/ecotalecoins/currency/CoinType.java
+++ b/src/main/java/com/ecotalecoins/currency/CoinType.java
@@ -1,26 +1,110 @@
 package com.ecotalecoins.currency;
 
-/**
- * Currency types using vanilla Hytale metal ingots.
- * Values are in base units (1 Copper Bar = 1 unit).
- * Uses vanilla game items instead of custom coins.
- */
-public enum CoinType {
-    COPPER("Ingredient_Bar_Copper", 1, "Copper Bar"),
-    IRON("Ingredient_Bar_Iron", 10, "Iron Bar"),
-    COBALT("Ingredient_Bar_Cobalt", 100, "Cobalt Bar"),
-    GOLD("Ingredient_Bar_Gold", 1_000, "Gold Bar"),
-    MITHRIL("Ingredient_Bar_Mithril", 10_000, "Mithril Bar"),
-    ADAMANTITE("Ingredient_Bar_Adamantite", 100_000, "Adamantite Bar");
+import com.ecotalecoins.config.CurrencyTierConfig;
+import com.ecotalecoins.config.EcotaleCoinsConfig;
 
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Currency type loaded from configuration.
+ * Replaces hard-coded enum with config-driven currency system.
+ *
+ * Currency types are loaded from EcotaleCoins.json on plugin startup.
+ * This allows server owners to customize which items are used as currency
+ * and their values without recompiling.
+ */
+public class CoinType {
+
+    private static final Map<String, CoinType> BY_NAME = new LinkedHashMap<>();
+    private static final Map<String, CoinType> BY_ITEM_ID = new HashMap<>();
+    private static boolean initialized = false;
+
+    private final String name;
     private final String itemId;
     private final long value;
     private final String displayName;
 
-    CoinType(String itemId, long value, String displayName) {
+    private CoinType(String name, String itemId, long value, String displayName) {
+        this.name = name;
         this.itemId = itemId;
         this.value = value;
         this.displayName = displayName;
+    }
+
+    /**
+     * Initialize currency types from configuration.
+     * Must be called before using any CoinType methods.
+     *
+     * @param config The EcotaleCoins configuration
+     */
+    public static void initialize(EcotaleCoinsConfig config) {
+        if (initialized) {
+            BY_NAME.clear();
+            BY_ITEM_ID.clear();
+        }
+
+        for (Map.Entry<String, CurrencyTierConfig> entry : config.getCurrencyTiers().entrySet()) {
+            String tierName = entry.getKey();
+            CurrencyTierConfig tierConfig = entry.getValue();
+
+            CoinType coinType = new CoinType(
+                tierName,
+                tierConfig.getItemId(),
+                tierConfig.getValue(),
+                tierConfig.getDisplayName()
+            );
+
+            BY_NAME.put(tierName, coinType);
+            BY_ITEM_ID.put(tierConfig.getItemId(), coinType);
+        }
+
+        initialized = true;
+    }
+
+    /**
+     * Get coin type by tier name (e.g., "COPPER", "GOLD").
+     * @return CoinType or null if not found
+     */
+    public static CoinType byName(String name) {
+        return BY_NAME.get(name);
+    }
+
+    /**
+     * Find coin type by item ID.
+     * @return CoinType or null if not a valid currency item
+     */
+    public static CoinType fromItemId(String itemId) {
+        return BY_ITEM_ID.get(itemId);
+    }
+
+    /**
+     * Check if an item ID is a valid currency item.
+     */
+    public static boolean isCoin(String itemId) {
+        return BY_ITEM_ID.containsKey(itemId);
+    }
+
+    /**
+     * Get all coin types in order (lowest to highest value).
+     */
+    public static CoinType[] values() {
+        return BY_NAME.values().toArray(new CoinType[0]);
+    }
+
+    /**
+     * Get all coin types sorted by value descending (for consolidation).
+     */
+    public static CoinType[] valuesDescending() {
+        List<CoinType> sorted = new ArrayList<>(BY_NAME.values());
+        sorted.sort(Comparator.comparingLong(CoinType::getValue).reversed());
+        return sorted.toArray(new CoinType[0]);
+    }
+
+    // Getters
+
+    public String name() {
+        return name;
     }
 
     public String getItemId() {
@@ -35,35 +119,22 @@ public enum CoinType {
         return displayName;
     }
 
-    /**
-     * Find coin type by item ID.
-     * @return CoinType or null if not a valid coin
-     */
-    public static CoinType fromItemId(String itemId) {
-        for (CoinType type : values()) {
-            if (type.itemId.equals(itemId)) {
-                return type;
-            }
-        }
-        return null;
+    @Override
+    public String toString() {
+        return name;
     }
 
-    /**
-     * Check if an item ID is a valid coin.
-     */
-    public static boolean isCoin(String itemId) {
-        return fromItemId(itemId) != null;
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!(obj instanceof CoinType)) return false;
+        CoinType other = (CoinType) obj;
+        return name.equals(other.name);
     }
 
-    /**
-     * Get all coin types sorted by value descending (for consolidation).
-     */
-    public static CoinType[] valuesDescending() {
-        CoinType[] types = values();
-        CoinType[] result = new CoinType[types.length];
-        for (int i = 0; i < types.length; i++) {
-            result[i] = types[types.length - 1 - i];
-        }
-        return result;
+    @Override
+    public int hashCode() {
+        return name.hashCode();
     }
 }
+

--- a/src/main/java/com/ecotalecoins/currency/InventorySpaceCalculator.java
+++ b/src/main/java/com/ecotalecoins/currency/InventorySpaceCalculator.java
@@ -28,7 +28,7 @@ public final class InventorySpaceCalculator {
      * NOTE: Only analyzes storage, not hotbar, to match giveSpecificCoins behavior.
      */
     public static Map<CoinType, CoinStackInfo> analyzeInventory(@Nonnull Player player) {
-        Map<CoinType, CoinStackInfo> result = new EnumMap<>(CoinType.class);
+        Map<CoinType, CoinStackInfo> result = new java.util.LinkedHashMap<>();
 
         for (CoinType type : CoinType.values()) {
             result.put(type, CoinStackInfo.empty(type));

--- a/src/main/java/com/ecotalecoins/gui/BankGui.java
+++ b/src/main/java/com/ecotalecoins/gui/BankGui.java
@@ -925,14 +925,10 @@ public class BankGui extends InteractiveCustomUIPage<BankGui.BankGuiData> {
     
     /** Get translated coin names */
     private String getCoinName(CoinType type) {
-        return switch (type) {
-            case COPPER -> t("coins.copper", "Copper");
-            case IRON -> t("coins.iron", "Iron");
-            case COBALT -> t("coins.cobalt", "Cobalt");
-            case GOLD -> t("coins.gold", "Gold");
-            case MITHRIL -> t("coins.mithril", "Mithril");
-            case ADAMANTITE -> t("coins.adamantite", "Adamantite");
-        };
+        // Use the display name from config
+        // Fallback to translation key based on tier name for backwards compatibility
+        String tierName = type.name().toLowerCase();
+        return t("coins." + tierName, type.getDisplayName());
     }
     
     private String formatLong(long value) {


### PR DESCRIPTION
## Problem
When depositing an amount that can't be made with exact change, the system would take more coins than needed, try to give change back, but fail because the smallest denomination couldn't make the change. This caused inconsistent and unpredictable deposit amounts.

### Example with $3 copper coins:
**User's scenario:**
- User has copper bars set to $3 each
- User deposits $5 value
- System takes 2 copper bars (Math.ceil(5/3) = 2) = $6 total value
- Tries to give $1 change back
- Can't make $1 with $3 copper coins (smallest denomination)
- Change is lost
- Inconsistent amount deposited

**User report:**
> "i have copper ingots set to $3 but when i deposit 5 of them I only get 7 coin"

The user expected the system to auto-round the deposit to the nearest denomination ($6 in this case), not try to make exact change.

## Solution
Created a new `takeCoinsForDeposit()` method that:
1. Takes coins to cover the requested amount (uses Math.ceil for rounding up)
2. **Does NOT attempt to give change back**
3. Returns the actual amount taken
4. Deposits exactly what was taken from inventory

### New behavior with $3 copper:
- User deposits $5
- System takes 2 copper bars = $6
- Deposits exactly $6 to bank (no change attempted)
- Shows message: **"Deposited $6 to bank (rounded up from $5)"**

This is the expected behavior when decimals are disabled in the economy - deposits round up to the nearest denomination that can be made with available coins.

## Changes
**File: `src/main/java/com/ecotalecoins/currency/CoinManager.java`**
- Added new method `takeCoinsForDeposit(Player, long)` that takes coins without giving change
- Returns actual amount taken (may be more than requested due to rounding)
- Documented that this is specifically for deposits where rounding up is expected

**File: `src/main/java/com/ecotalecoins/transaction/SecureTransaction.java`**
- Updated `executeSecureDeposit()` to use `takeCoinsForDeposit()` instead of `takeCoins()`
- Simplified balance calculation - just use return value from takeCoinsForDeposit
- Added success message for rounded-up deposits: `"Deposited {0} to bank (rounded up from {1})"`
- Removed old partial deposit logic (no longer needed with new approach)

## Testing
Tested with:
- Copper bars at $3 each
- Depositing $5 now correctly:
  - Takes 2 copper bars ($6 total)
  - Deposits exactly $6 to bank
  - Shows rounded-up message
- No more inconsistent amounts or lost change

Fixes deposit rounding issues when using non-decimal economies with denominations that don't divide evenly.